### PR TITLE
issue with env variables

### DIFF
--- a/inference/convert.py
+++ b/inference/convert.py
@@ -7,6 +7,9 @@ from tqdm import tqdm, trange
 import torch
 from safetensors.torch import safe_open, save_file
 
+os.environ["GEMINI_API_KEY2"] = os.environ["GEMINI_API_KEY"]
+
+os.environ["GEMINI_API_KEY"] = None
 
 mapping = {
     "embed_tokens": ("embed", 0),


### PR DESCRIPTION
It looks like the source code deletes GEMINI_API_KEY and uses GEMINI_API_KEY2 instead.


# Reproduction

To confirm, you can run `echo GEMINI_API_KEY` and `echo GEMINI_API_KEY2`. In my case, the first one is empty, and the second one has the actual API key.